### PR TITLE
Support for using local server added in CLI

### DIFF
--- a/cli/audio_extract.py
+++ b/cli/audio_extract.py
@@ -1,5 +1,6 @@
 import ffmpeg
 import sys
+import os
 
 BITRATE = 1000*16
 
@@ -24,6 +25,9 @@ def extract(path, quality="medium"):
     try:
         file = ffmpeg.input(path)
         output_path = path[:-3]+"ogg"
+        if(os.path.exists(output_path)):
+            print(f"Audio file {output_path} already exists")
+            return output_path
         print("Extracting audio for file %s" % (path))
         file.audio.output(output_path, acodec='libvorbis',
                           audio_bitrate=BITRATE*get_multiplier(quality), loglevel=0).run()

--- a/cli/main.py
+++ b/cli/main.py
@@ -95,10 +95,8 @@ if __name__ == '__main__':
             if(e or not e):
                 title = getRandomString(10)
 
-        # name = getRandomString(5)
-        # server.upload(name,audio_files[i])
-
-        server.create_room(title, args.onlyHost)
+        audioPath = '/home/saptarshi/Downloads/mhaop.mp3'
+        server.create_room(title, audioPath, args.onlyHost)
 
     # To do --> Add support for changing items in playlist.
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -52,7 +52,8 @@ def convert_async():
         args.f, [args.q]), callback=files.extend)
 
     p.wait()
-    print(f"Completed extraction of {len(args.f)} files in {time.perf_counter()-st} seconds")
+    print(
+        f"Completed extraction of {len(args.f)} files in {time.perf_counter()-st} seconds")
     return files
 
 ######################################
@@ -95,8 +96,15 @@ if __name__ == '__main__':
             if(e or not e):
                 title = getRandomString(10)
 
-        audioPath = '/home/saptarshi/Downloads/mhaop.mp3'
-        server.create_room(title, audioPath, args.onlyHost)
+        if args.web:
+            name = getRandomString(5)
+            # server.upload(name,audio_files[i])
+            # server.upload(name,'/home/saptarshi/Downloads/mhaop.mp3')
+        else:
+            audioPath = '/home/saptarshi/Downloads/mhaop.mp3'  # modify
+            server.addAudioPath(audioPath)
+
+        server.create_room(title, args.onlyHost, args.web)
 
     # To do --> Add support for changing items in playlist.
 

--- a/cli/server_comm.py
+++ b/cli/server_comm.py
@@ -59,11 +59,12 @@ class ServerConnection():
     def __init__(self):
         self.sio = socketio.Client()
         self.sio.connect('http://localhost:5000')
-
+        from main import parse
+        self.args = parse()
         # For testing purposes...
         self.trackId = '5ed554389cd979784f6926e3'   # Bella-Caio
         # self.trackId = '5ed88aae25f4787bea4cc07f'     # Dark
-        self.trackId = '5ee350d3c67ae85cae6f669c'    # mha op
+        # self.trackId = '5ee350d3c67ae85cae6f669c'    # mha op
 
     def send(self,  signal,  data):
         """ Used to send data to the server with a corresponding signal"""
@@ -76,15 +77,14 @@ class ServerConnection():
         self.signals.bind()
         self.sio.register_namespace(self.signals)
 
-    def create_room(self, title, onlyHost, web):
-        print(web, self.trackId)
-        if web:
+    def create_room(self, title):
+        if self.args.web:
             print('track Id is ', self.trackId)
             self.send('createRoom', {
-                      'title': title, 'trackId': self.trackId, 'onlyHost': onlyHost})
+                      'title': title, 'trackId': self.trackId, 'onlyHost': self.args.onlyHost})
         else:
             self.send('createRoom', {
-                      'title': title, 'audioPath': self.audioPath, 'onlyHost': onlyHost})
+                      'title': title, 'audioPath': self.audioPath, 'onlyHost': self.args.onlyHost})
 
     def upload(self,  fileName,  path):
         """ Uploads audio file to the webserver """

--- a/cli/server_comm.py
+++ b/cli/server_comm.py
@@ -55,8 +55,9 @@ class ServerConnection():
         self.sio.connect('http://localhost:5000')
 
         # For testing purposes...
-        self.trackId = '5ed554389cd979784f6926e3'   # Bella-Caio
+        # self.trackId = '5ed554389cd979784f6926e3'   # Bella-Caio
         # self.trackId = '5ed88aae25f4787bea4cc07f'     # Dark
+        # self.trackId = '5ee28c108dbcaf56c44c1e13'    # mha op
 
     def send(self,  signal,  data):
         """ Used to send data to the server with a corresponding signal"""
@@ -69,15 +70,15 @@ class ServerConnection():
         self.signals.bind()
         self.sio.register_namespace(self.signals)
 
-    def create_room(self, title, onlyHost):
-        self.send('createRoom', {'title': title, 'trackId': self.trackId, 'onlyHost': onlyHost})
+    def create_room(self, title, path, onlyHost):
+        self.send('createRoom', {'title': title, 'audioPath': path, 'onlyHost': onlyHost})
 
-    def upload(self,  fileName,  path):
-        """ Uploads audio file to the webserver """
-        print("Uploading to server")
-        import requests
-        url = f"{SERVER_ADDR}/api/upload/"
-        files = {'file': (fileName,  open(path,  'rb'),  'audio/ogg')}
-        r = requests.post(url=url, files=files, data={"title": fileName})
-        print(r.json())
-        self.trackId = r.json()['trackId']
+    # def upload(self,  fileName,  path):
+    #     """ Uploads audio file to the webserver """
+    #     print("Uploading to server")
+    #     import requests
+    #     url = f"{SERVER_ADDR}/api/upload/"
+    #     files = {'file': (fileName,  open(path,  'rb'),  'audio/ogg')}
+    #     r = requests.post(url=url, files=files, data={"title": fileName})
+    #     print(r.json())
+    #     self.trackId = r.json()['trackId']

--- a/cli/server_comm.py
+++ b/cli/server_comm.py
@@ -2,7 +2,7 @@ import socketio
 import time
 import psutil
 
-SERVER_ADDR = "http://localhost:5000"
+SERVER_ADDR = "localhost"
 
 
 # this is used internally by ServerConnection
@@ -42,13 +42,17 @@ class VLC_signals(socketio.ClientNamespace):
 
     def on_createRoom(self, *args,  **kwargs):
         self.roomId = args[0]['roomId']
-
-        addrs = psutil.net_if_addrs()
-        local_addr = addrs['wlp3s0'][0].address       # modify
-        url = f"http://{local_addr}:5000/client/stream/?roomId={self.roomId}"
-        print(f"Please visit {url}")
         from main import parse
-        if(parse().qr):
+        args = parse()
+        url = "http://%s:5000/client/stream/?roomId=%s"
+        if(args.web):
+            url = url % (SERVER_ADDR, self.roomId)
+        else:
+            addrs = psutil.net_if_addrs()
+            local_addr = addrs['wlp3s0'][0].address       # modify
+            url = url % (local_addr, self.roomId)
+        print(f"Please visit {url}")
+        if(args.qr):
             from util import print_qr
             print("Or scan the QR code given below")
             print_qr(url)

--- a/cli/server_comm.py
+++ b/cli/server_comm.py
@@ -1,5 +1,7 @@
 import socketio
 import time
+import psutil
+
 SERVER_ADDR = "http://localhost:5000"
 
 
@@ -35,11 +37,15 @@ class VLC_signals(socketio.ClientNamespace):
     def on_seek(self,  *args,  **kwargs):
         state = args[0]
         print("Seek signal recieved with the following data", state)
-        self.player.seek(int(time.time() - state['last_updated'] + state['position']))
+        self.player.seek(
+            int(time.time() - state['last_updated'] + state['position']))
 
     def on_createRoom(self, *args,  **kwargs):
         self.roomId = args[0]['roomId']
-        url = f"http://localhost:5000/client/stream/?roomId={self.roomId}"
+
+        addrs = psutil.net_if_addrs()
+        local_addr = addrs['wlp3s0'][0].address       # modify
+        url = f"http://{local_addr}:5000/client/stream/?roomId={self.roomId}"
         print(f"Please visit {url}")
         from main import parse
         if(parse().qr):
@@ -55,9 +61,9 @@ class ServerConnection():
         self.sio.connect('http://localhost:5000')
 
         # For testing purposes...
-        # self.trackId = '5ed554389cd979784f6926e3'   # Bella-Caio
+        self.trackId = '5ed554389cd979784f6926e3'   # Bella-Caio
         # self.trackId = '5ed88aae25f4787bea4cc07f'     # Dark
-        # self.trackId = '5ee28c108dbcaf56c44c1e13'    # mha op
+        self.trackId = '5ee350d3c67ae85cae6f669c'    # mha op
 
     def send(self,  signal,  data):
         """ Used to send data to the server with a corresponding signal"""
@@ -70,15 +76,25 @@ class ServerConnection():
         self.signals.bind()
         self.sio.register_namespace(self.signals)
 
-    def create_room(self, title, path, onlyHost):
-        self.send('createRoom', {'title': title, 'audioPath': path, 'onlyHost': onlyHost})
+    def create_room(self, title, onlyHost, web):
+        print(web, self.trackId)
+        if web:
+            print('track Id is ', self.trackId)
+            self.send('createRoom', {
+                      'title': title, 'trackId': self.trackId, 'onlyHost': onlyHost})
+        else:
+            self.send('createRoom', {
+                      'title': title, 'audioPath': self.audioPath, 'onlyHost': onlyHost})
 
-    # def upload(self,  fileName,  path):
-    #     """ Uploads audio file to the webserver """
-    #     print("Uploading to server")
-    #     import requests
-    #     url = f"{SERVER_ADDR}/api/upload/"
-    #     files = {'file': (fileName,  open(path,  'rb'),  'audio/ogg')}
-    #     r = requests.post(url=url, files=files, data={"title": fileName})
-    #     print(r.json())
-    #     self.trackId = r.json()['trackId']
+    def upload(self,  fileName,  path):
+        """ Uploads audio file to the webserver """
+        print("Uploading to server")
+        import requests
+        url = f"{SERVER_ADDR}/api/upload/"
+        files = {'file': (fileName,  open(path,  'rb'),  'audio/ogg')}
+        r = requests.post(url=url, files=files, data={"title": fileName})
+        print(r.json())
+        self.trackId = r.json()['trackId']
+
+    def addAudioPath(self, audioPath):
+        self.audioPath = audioPath

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ chardet==3.0.4
 ffmpeg-python==0.2.0
 future==0.18.2
 idna==2.9
+psutil==5.7.0
 PyQRCode==1.2.1
 python-engineio==3.12.1
 python-socketio==4.5.1


### PR DESCRIPTION
### Note to the reviewer
- The server that the CLI uses for hosting a local server can be obtained at [https://github.com/Harsh14901/CommonAudioVideoServer.git](https://github.com/Harsh14901/CommonAudioVideoServer.git) **Please checkout to the branch `local` before running the CLI**
- Please ensure that `CommonAudioVideoServer` repo is cloned in the same directory under which `CommonAudioVideoCLI` repo lies. Either do this or change the `SERVER_PATH` global variable in `main.py` according to your wish.
- The CLI is configured only for network interfaces `wlp3s0`. It has to made generic to support all laptops. This is used to derive the local IP address of the machine. If your machine has a different name for the wireless interface please find and replace `wlp3s0` with `<your_interface>` in `server_comm.py`

We aim to resolve these issues in the forthcoming PR's
- The local server repo will be packaged with the CLI itself, so this won't be much of a problem
- **Pending** : Alternative solution for finding the local IP address